### PR TITLE
<feat>add a basic gds editor

### DIFF
--- a/GUI/gui_modules/Display/gds_editor.py
+++ b/GUI/gui_modules/Display/gds_editor.py
@@ -1,0 +1,163 @@
+from PyQt5.QtWidgets import QApplication, QWidget
+from PyQt5.QtCore import Qt, QRect
+
+from OCC.Display.OCCViewer import Viewer3d
+from OCC.Core import gp, BRepBuilderAPI, Quantity
+
+
+class GdsEditor(QWidget):
+    def __init__(self, parent=None):
+        QWidget.__init__(self, parent)
+        # enable Mouse Tracking
+        self.setMouseTracking(True)
+
+        # Strong focus
+        self.setFocusPolicy(Qt.FocusPolicy.WheelFocus)
+
+        self.setAttribute(Qt.WidgetAttribute.WA_NativeWindow)
+        self.setAttribute(Qt.WidgetAttribute.WA_PaintOnScreen)
+        self.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground)
+
+        self.setAutoFillBackground(False)
+
+        # occ 3dviewer
+        self._display = Viewer3d()
+        self._display.Create(window_handle=int(
+            self.winId()), parent=self, create_default_lights=False, display_glinfo=False)
+        # background gradient
+        self._display.SetModeShaded()
+        # fix top view
+        self._display.View_Top()
+        self._display.set_bg_gradient_color([0, 10, 10], [0, 10, 10])
+
+        self._pan_start_x = None
+        self._pan_start_y = None
+        self._drawbox = False
+
+        self._move_start_x = None
+        self._move_start_y = None
+
+        self._selected_shape = None
+
+    def resizeEvent(self, event):
+        super(GdsEditor, self).resizeEvent(event)
+        self._display.View.MustBeResized()
+
+    def paintEngine(self):
+        return None
+
+    def keyPressEvent(self, event):
+        super(GdsEditor, self).keyPressEvent(event)
+
+    def focusInEvent(self, event):
+        self._display.Repaint()
+
+    def focusOutEvent(self, event):
+        self._display.Repaint()
+
+    def paintEvent(self, event):
+        self._display.Context.UpdateCurrentViewer()
+
+    def wheelEvent(self, event):
+        delta = event.angleDelta().y()
+        zoom_factor = 1.25 if delta > 0 else 0.75
+        self._display.ZoomFactor(zoom_factor)
+
+    def mousePressEvent(self, event):
+        # self.setFocus()
+        pos = event.pos()
+        button = event.button()
+        # use left mouse button to pan
+        if button == Qt.MouseButton.LeftButton:
+            self._pan_start_x = pos.x()
+            self._pan_start_y = pos.y()
+        elif button == Qt.MouseButton.RightButton:
+            self._move_start_x = pos.x()
+            self._move_start_y = pos.y()
+            self._display.Context.ClearSelected(True)
+            self._display.Select(pos.x(), pos.y())
+            self._selected_shape = self._display.Context.SelectedInteractive()
+
+    def mouseMoveEvent(self, event):
+        pos = event.pos()
+        buttons = event.buttons()
+        # use left mouse button to pan
+        if buttons == Qt.MouseButton.LeftButton:
+            dx = pos.x() - self._pan_start_x
+            dy = pos.y() - self._pan_start_y
+            self._pan_start_x = pos.x()
+            self._pan_start_y = pos.y()
+            self._display.Pan(dx, -dy)
+        if buttons == Qt.MouseButton.RightButton and self._selected_shape:
+            # translate view coord to real coord
+            view = self._display.View
+            v1 = view.Convert(self._move_start_x, self._move_start_y)
+            v2 = view.Convert(pos.x(), pos.y())
+            move_vec = gp.gp_Vec(
+                gp.gp_Pnt(v1[0], v1[1], 0), gp.gp_Pnt(v2[0], v2[1], 0))
+            trsf = gp.gp_Trsf()
+            trsf.SetTranslation(move_vec)
+            self._selected_shape.SetLocalTransformation(
+                self._selected_shape.Transformation()*trsf)
+            self._display.Context.Update(self._selected_shape, True)
+
+            self._move_start_x = pos.x()
+            self._move_start_y = pos.y()
+        else:
+            self._display.MoveTo(pos.x(), pos.y())
+
+    def mouseReleaseEvent(self, event):
+        button = event.button()
+        if button == Qt.MouseButton.RightButton:
+            self._selected_shape = None
+            self._display.Context.ClearSelected(True)
+
+    def showTopoDS(self, component: list):
+        for i in component:
+            for s in i.shapes:
+                self._display.DisplayShape(
+                    s, color=Quantity.Quantity_NameOfColor.Quantity_NOC_CORAL, transparency=0.8)
+        viewer._display.FitAll()
+
+    def drawSelectBox(self, event):
+        tolerance = 2
+        pt = event.pos()
+        dx = pt.x() - self.dragStartPosX
+        dy = pt.y() - self.dragStartPosY
+        if abs(dx) <= tolerance and abs(dy) <= tolerance:
+            return
+        self._drawbox = [self.dragStartPosX, self.dragStartPosY, dx, dy]
+
+    def saveImage(self, path: str = None):
+        self._display.ExportToImage(path)
+
+
+if __name__ == "__main__":
+    import sys
+    import os
+    from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
+    current_path = os.path.dirname(os.path.abspath(__file__))
+    PROJ_PATH = os.path.abspath(os.path.join(
+        os.path.dirname(current_path), "../.."))
+    sys.path.append(PROJ_PATH)
+    from library.qubits import transmon
+    from library.coupling_lines import coupling_line_straight
+    import gdsocc
+    # from api.design import Design
+
+    # design = Design()
+    # design.generate_topology(topo_col=32, topo_row=32)
+    # design.topology.generate_random_edges(edges_num=1500)
+    # design.generate_qubits(
+    #     topology=True, qubits_type="Transmon", chip_name="chip0", dist=3000)
+    # design.gds.show_svg()
+
+    app = QApplication([])
+    viewer = GdsEditor()
+    qubit = transmon.Transmon({})
+    cpl = coupling_line_straight.CouplingLineStraight({})
+
+    viewer.showTopoDS([qubit.draw_shape(), cpl.draw_shape()])
+
+    viewer.show()
+    sys.exit(app.exec_())

--- a/gdsocc/__init__.py
+++ b/gdsocc/__init__.py
@@ -1,0 +1,1 @@
+from gdsocc.polygon import *

--- a/gdsocc/polygon.py
+++ b/gdsocc/polygon.py
@@ -1,0 +1,162 @@
+from OCC.Core import BRepBuilderAPI, BRepTools, TopExp, TopAbs, BRepAdaptor
+from OCC.Core import gp, BRep, BRepAlgoAPI
+from OCC.Core import BRepOffsetAPI
+from OCC.Core import Geom, Geom2d, GeomAbs
+
+import numpy
+
+
+class Polygon:
+    def __init__(self, points: list, layer=0, datatype=0, name=""):
+        self.layer = layer
+        self.datatype = datatype
+        self.name = name
+        self.shapes = []
+        if points:
+            polygon = BRepBuilderAPI.BRepBuilderAPI_MakePolygon()
+            for point in points:
+                polygon.Add(gp.gp_Pnt(*point, 0))
+            polygon.Close()
+            self.shapes.append(BRepBuilderAPI.BRepBuilderAPI_MakeFace(
+                polygon.Wire()).Face())
+        # self.polygon = BRepBuilderAPI.BRepBuilderAPI_MakeFace(
+        #     polygon.Wire()).Face()
+
+        self.properties = {}
+
+    def to_gds(self):
+        pass
+
+
+class Rectangle(Polygon):
+    def __init__(self, point1, point2, layer=0, datatype=0):
+        points = [[point1[0], point1[1]],
+                  [point1[0], point2[1]],
+                  [point2[0], point2[1]],
+                  [point2[0], point1[1]]]
+        super().__init__(points, layer, datatype)
+
+
+class Path(Polygon):
+    def __init__(self, width, initial_point=(0, 0), number_of_paths=1, distance=0):
+        super().__init__([])
+        self.x = initial_point[0]
+        self.y = initial_point[1]
+        self.spine = BRepBuilderAPI.BRepBuilderAPI_MakeWire()
+        self.edges = []
+        self.width = width * 0.5
+
+    def segment(self, length, direction):
+        if direction == "+x":
+            ca = 1
+            sa = 0
+        elif direction == "-x":
+            ca = -1
+            sa = 0
+        elif direction == "+y":
+            ca = 0
+            sa = 1
+        elif direction == "-y":
+            ca = 0
+            sa = -1
+        else:
+            ca = numpy.cos(direction)
+            sa = numpy.sin(direction)
+
+        next_x = self.x + length * ca
+        next_y = self.y + length * sa
+
+        edge = BRepBuilderAPI.BRepBuilderAPI_MakeEdge(
+            gp.gp_Pnt(self.x, self.y, 0), gp.gp_Pnt(next_x, next_y, 0)).Edge()
+        self.spine.Add(edge)
+        self.edges.append(edge)
+        self.x = next_x
+        self.y = next_y
+
+    def done(self):
+        # get tangent in wire start and end point
+        adaptor = BRepAdaptor.BRepAdaptor_CompCurve(self.spine.Wire())
+        first_param = adaptor.FirstParameter()
+        last_param = adaptor.LastParameter()
+
+        tangent_start = gp.gp_Vec()
+        tangent_end = gp.gp_Vec()
+        p_start = gp.gp_Pnt()
+        p_end = gp.gp_Pnt()
+
+        adaptor.D1(first_param, p_start, tangent_start)
+        adaptor.D1(last_param, p_end, tangent_end)
+
+        dir_start = gp.gp_Dir(tangent_start)
+        dir_end = gp.gp_Dir(tangent_end)
+
+        # make local axis in wire start end point and tangent vec
+        axis_global = gp.gp_Ax3(
+            gp.gp_Pnt(0, 0, 0), gp.gp_Dir(0, 0, 1), gp.gp_Dir(1, 0, 0))
+        axis_start = gp.gp_Ax3(p_start, gp.gp_Dir(0, 0, 1), dir_start)
+        axis_end = gp.gp_Ax3(p_end, gp.gp_Dir(0, 0, 1), dir_end)
+
+        # make a local box to cut off extend wire start and end
+        # box points in local axis
+        local_start_1 = gp.gp_Pnt(0, -self.width, 0)
+        local_start_2 = gp.gp_Pnt(0, +self.width, 0)
+        local_start_3 = gp.gp_Pnt(-self.width, +self.width, 0)
+        local_start_4 = gp.gp_Pnt(-self.width, -self.width, 0)
+        # translate local point to global axis
+        trsf_start = gp.gp_Trsf()
+        trsf_start.SetTransformation(axis_start, axis_global)
+        polygon_start = BRepBuilderAPI.BRepBuilderAPI_MakePolygon()
+        polygon_start.Add(local_start_1.Transformed(trsf_start))
+        polygon_start.Add(local_start_2.Transformed(trsf_start))
+        polygon_start.Add(local_start_3.Transformed(trsf_start))
+        polygon_start.Add(local_start_4.Transformed(trsf_start))
+        polygon_start.Close()
+        face_start = BRepBuilderAPI.BRepBuilderAPI_MakeFace(
+            polygon_start.Wire()).Face()
+
+        # do same thing for end point
+        local_end_1 = gp.gp_Pnt(0, -self.width, 0)
+        local_end_2 = gp.gp_Pnt(0, +self.width, 0)
+        local_end_3 = gp.gp_Pnt(self.width, +self.width, 0)
+        local_end_4 = gp.gp_Pnt(self.width, -self.width, 0)
+        # translate local point to global axis
+        trsf_end = gp.gp_Trsf()
+        trsf_end.SetTransformation(axis_end, axis_global)
+        polygon_end = BRepBuilderAPI.BRepBuilderAPI_MakePolygon()
+        polygon_end.Add(local_end_1.Transformed(trsf_end))
+        polygon_end.Add(local_end_2.Transformed(trsf_end))
+        polygon_end.Add(local_end_3.Transformed(trsf_end))
+        polygon_end.Add(local_end_4.Transformed(trsf_end))
+        polygon_end.Close()
+        face_end = BRepBuilderAPI.BRepBuilderAPI_MakeFace(
+            polygon_end.Wire()).Face()
+
+        # BRepOffsetAPI_MakeOffset require wire must be closed
+        # so we add reverse edges of wire to close it
+        exp = TopExp.TopExp_Explorer(self.spine.Wire(), TopAbs.TopAbs_EDGE)
+        reversed_edge = []
+        while exp.More():
+            edge = exp.Current()
+            r_edge = edge.Reversed()
+            reversed_edge.append(r_edge)
+            exp.Next()
+        for i in reversed(reversed_edge):
+            self.spine.Add(i)
+        offset = BRepOffsetAPI.BRepOffsetAPI_MakeOffset(
+            self.spine.Wire(), GeomAbs.GeomAbs_Arc)
+        offset.Perform(self.width)
+        polygon = BRepBuilderAPI.BRepBuilderAPI_MakeFace(
+            offset.Shape()).Face()
+
+        # as GeomAbs.GeomAbs_Arc make start/end point a arc, we cut off it
+        opt_start = BRepAlgoAPI.BRepAlgoAPI_Cut(polygon, face_start)
+        polygon = opt_start.Shape()
+        opt_start = BRepAlgoAPI.BRepAlgoAPI_Cut(polygon, face_end)
+        polygon = opt_start.Shape()
+        self.shapes.append(polygon)
+
+
+if __name__ == "__main__":
+    cpw = Path(40, [0.5, 0.5])
+    cpw.segment(1000, direction="+x")
+    cpw.done()

--- a/library/coupling_lines/coupling_line_straight.py
+++ b/library/coupling_lines/coupling_line_straight.py
@@ -8,6 +8,12 @@ from base.library_base import LibraryBase
 import toolbox
 import copy, gdspy
 import numpy as np
+import os, sys
+POJECT_ROOT =os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")
+if POJECT_ROOT not in sys.path:
+    sys.path.append(POJECT_ROOT)
+import gdsocc 
+from OCC.Core import BRepAlgoAPI 
 
 class CouplingLineStraight(LibraryBase):
     """
@@ -77,3 +83,21 @@ class CouplingLineStraight(LibraryBase):
         self.cell = self.lib.new_cell(self.name + "_cell")
         self.cell.add(sub_poly)
         return
+    
+    def draw_shape(self):
+        # FIXME:use gdspy.PolyPath like interface
+        path_sub = gdsocc.Path(self.width, self.start_pos)
+        path_sub.segment(500, "+x")
+        path_sub.done()
+
+        path = gdsocc.Path(self.width + self.gap*2, self.start_pos)
+        path.segment(500, "+x")
+        path.done()
+
+        for idx in range(len(path.shapes)):
+            for c in path_sub.shapes:
+                s = path.shapes[idx]
+                cut_op = BRepAlgoAPI.BRepAlgoAPI_Cut(s, c)
+                path.shapes[idx] = cut_op.Shape()
+        
+        return path

--- a/library/qubits/transmon.py
+++ b/library/qubits/transmon.py
@@ -6,6 +6,13 @@
 from addict import Dict
 from base.library_base import LibraryBase
 import gdspy, numpy as np
+import os, sys
+POJECT_ROOT =os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")
+if POJECT_ROOT not in sys.path:
+    sys.path.append(POJECT_ROOT)
+import gdsocc 
+from OCC.Core import BRepAlgoAPI 
+
 
 class Transmon(LibraryBase):
     default_options = Dict(
@@ -215,3 +222,126 @@ class Transmon(LibraryBase):
         self.cell = self.lib.new_cell(self.name + "_cell")
         self.cell.add(sub_poly)
         return
+    
+    def draw_shape(self):
+        """
+        Draws the geometric shapes of the Transmon.
+        """
+        subtract_shape = []
+        
+        # Retrieve parameters from options
+        width = self.width
+        height = self.height
+        cpw_width = self.cpw_width
+        cpw_extend = self.cpw_extend
+        gap = self.gap
+        pad_options = self.pad_options
+        pad_gap = self.pad_gap
+        pad_height = self.pad_height
+        pad_width = self.pad_width
+        cpw_pos = self.cpw_pos
+        gds_pos = self.gds_pos
+        control_distance = self.control_distance
+        subtract_gap = self.subtract_gap
+        subtract_width = self.subtract_width
+        subtract_height = self.subtract_height
+
+        # Check if the main rectangle width is large enough to accommodate all pads
+        total_pad_height_upper = sum([x * y for x, y in zip(pad_width[:3], pad_options[:3])])
+        total_pad_height_lower = sum([x * y for x, y in zip(pad_width[-3:], pad_options[-3:])])
+        if width < total_pad_height_upper and width < total_pad_height_lower:
+            raise ValueError("The main rectangle width is too small to accommodate all pads.")
+
+        # Calculate the main body center coordinates
+        main_body_x = gds_pos[0]
+        main_body_y = gds_pos[1]
+        
+        # Calculate the coordinates of the four corners of the upper rectangle
+        upper_left = [main_body_x - width/2, main_body_y + gap/2 + height]
+        upper_right = [main_body_x + width/2, main_body_y + gap/2 + height]
+        upper_center = [main_body_x, main_body_y + gap/2 + height]
+        
+        # Calculate the coordinates of the four corners of the lower rectangle
+        lower_left = [main_body_x - width/2, main_body_y - gap/2 - height]
+        lower_right = [main_body_x + width/2, main_body_y - gap/2 - height]
+        lower_center = [main_body_x, main_body_y - gap/2 - height]
+        
+        # Create the upper rectangle shape
+        rect_upper = gdsocc.Rectangle(
+            (main_body_x - width/2, main_body_y + gap/2),
+            (main_body_x + width/2, main_body_y + height + gap/2)
+        )
+        subtract_shape.append(rect_upper)
+        
+        # Create the lower rectangle shape
+        rect_lower = gdsocc.Rectangle(
+            (main_body_x - width/2, main_body_y - height - gap/2),
+            (main_body_x + width/2, main_body_y - gap/2)
+        )
+        subtract_shape.append(rect_lower)
+        
+        # Add connection pads
+        cpw_positions = [upper_left, upper_center, upper_right, lower_left, lower_center, lower_right]
+        for i in range(6):
+            if pad_options[i] == 1:
+                # Calculate the x-coordinate of the pad, ensuring it does not exceed the main rectangle boundaries
+                pad_x = max(main_body_x - width / 2 + pad_width[i] / 2, min(main_body_x + width / 2 - pad_width[i] / 2, cpw_positions[i][0]))
+                pad_y = cpw_positions[i][1] + (pad_gap[i] if i < 3 else -pad_gap[i])
+                
+                # Create the pad shape (rectangle)
+                pad = gdsocc.Rectangle(
+                    (pad_x - pad_width[i]/2, pad_y),
+                    (pad_x + pad_width[i]/2, pad_y + pad_height[i]) if i < 3 else (pad_x + pad_width[i]/2, pad_y - pad_height[i])
+                )
+                subtract_shape.append(pad)
+
+                # Calculate the direction angle (convert to radians if needed)
+                if i == 0 or i == 3:  # Left CPW, direction left
+                    direction_degrees = 180
+                elif i == 1 or i == 4:  # Middle CPW, direction up or down
+                    direction_degrees = 90 if i == 1 else -90
+                else:  # Right CPW, direction right
+                    direction_degrees = 0
+                    
+                direction_radians = np.radians(direction_degrees)
+                
+                # Create the CPW line
+                # Calculate the start coordinates
+                if i == 0 or i == 3:  # Upper left and lower left, start at the left boundary of the pad
+                    cpw_start = [pad_x - pad_width[i]/2, pad_y + pad_height[i]/2] if i == 0 else [pad_x - pad_width[i]/2, pad_y - pad_height[i]/2]
+                    
+                elif i == 1 or i == 4:  # Middle two, upper and lower boundaries
+                    cpw_start = [pad_x, pad_y + pad_height[i]] if i == 1 else [pad_x, pad_y - pad_height[i]]
+                else:  # Upper right and lower right, start at the right boundary of the pad
+                    cpw_start = [pad_x + pad_width[i]/2, pad_y + pad_height[i]/2] if i == 2 else [pad_x + pad_width[i]/2, pad_y - pad_height[i]/2]
+
+                cpw = gdsocc.Path(cpw_width[i], cpw_start)
+                cpw.segment(cpw_extend[i], direction=direction_radians)
+                cpw.done()
+                subtract_shape.append(cpw)
+
+
+        indices = [i for i, value in enumerate(pad_options) if value == 1]
+        max_extend_value = max(cpw_extend[i] for i in indices)
+        max_pad_gap = max(pad_gap[i] for i in indices)
+        max_pad_height = max(pad_height[i] for i in indices) 
+        if sum(pad_options) == 0 or max_extend_value < subtract_gap:
+            subtract_square = gdsocc.Rectangle((main_body_x - width/2 - subtract_gap, main_body_y + height + gap/2 + subtract_gap),
+                                              (main_body_x + width/2 + subtract_gap, main_body_y - height - gap/2 - subtract_gap))
+            self.pocket_pos = [[main_body_x - width/2 - subtract_gap, main_body_y + height + gap/2 + subtract_gap],
+                               [main_body_x + width/2 + subtract_gap, main_body_y - height - gap/2 - subtract_gap]]
+        else:
+            subtract_square = gdsocc.Rectangle((main_body_x - width/2 - max_extend_value, main_body_y + height + gap/2 + max_extend_value + max_pad_gap + max_pad_height),
+                                              (main_body_x + width/2 + max_extend_value, main_body_y - height - gap/2 - max_extend_value - max_pad_height - max_pad_gap))
+            self.pocket_pos = [[main_body_x - width/2 - max_extend_value, main_body_y + height + gap/2 + max_extend_value + max_pad_gap + max_pad_height],
+                               [main_body_x + width/2 + max_extend_value, main_body_y - height - gap/2 - max_extend_value - max_pad_height - max_pad_gap]]
+
+        for idx in range(len(subtract_square.shapes)):
+            for comp in subtract_shape:
+                for c in comp.shapes:
+                    s = subtract_square.shapes[idx]
+                    cut_op = BRepAlgoAPI.BRepAlgoAPI_Cut(s, c)
+                    subtract_square.shapes[idx] = cut_op.Shape()
+
+
+        return subtract_square


### PR DESCRIPTION
![gdseditor](https://github.com/user-attachments/assets/9ba7230a-a55f-4c4e-9fff-d5d06dfd4ad7)

Add a basic gds layout editor. Just run gds_editor.py to feel it.
Hold left mouse button to pan layout, hold right mouse button to move.
It's a demo, much work left to do, like modify layout, modify compoent, save as gds file ....

And there's another new idea. Remmber the python interpretor? I want to click the component gds layout, then the component python object appears in the python interpretor. Change it by python code,  then update to editor.