### PR TITLE
<feat>interactive gdseditor with python interpretor

### DIFF
--- a/GUI/gui_modules/Display/gds_editor.py
+++ b/GUI/gui_modules/Display/gds_editor.py
@@ -1,11 +1,37 @@
-from PyQt5.QtWidgets import QApplication, QWidget
-from PyQt5.QtCore import Qt, QRect
+from PyQt5.QtWidgets import QApplication, QWidget, QMenu
+from PyQt5.QtCore import Qt, QSize, pyqtSignal, QPoint
 
 from OCC.Display.OCCViewer import Viewer3d
-from OCC.Core import gp, BRepBuilderAPI, Quantity
+from OCC.Core import gp, BRepBuilderAPI, Quantity, AIS
+
+import networkx as nx
+
+from enum import IntEnum
 
 
 class GdsEditor(QWidget):
+
+    class Action(IntEnum):
+        SHOW_IN_INTERPRETER = 0
+
+    sendObjToInterpreter = pyqtSignal(dict)
+
+    class RightButtonMenu(QMenu):
+        """
+        Menu for right click
+        """
+        action_triggered = pyqtSignal(int, QPoint)
+
+        def __init__(self, parent=None):
+            QMenu.__init__(self, parent)
+            self.cur_pos = None
+            self.addAction("Show in interpreter").triggered.connect(
+                lambda chcek, self=self: self.action_triggered.emit(GdsEditor.Action.SHOW_IN_INTERPRETER.value, self.cur_pos))
+
+        def popup(self, p, action=None):
+            self.cur_pos = p
+            return super().popup(p, action)
+
     def __init__(self, parent=None):
         QWidget.__init__(self, parent)
         # enable Mouse Tracking
@@ -19,6 +45,12 @@ class GdsEditor(QWidget):
         self.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground)
 
         self.setAutoFillBackground(False)
+
+        self.right_menu = GdsEditor.RightButtonMenu(self)
+        self.right_menu.action_triggered.connect(self.handleMenuAction)
+
+        # use digraph to store component and shape relation
+        self.component_shape_map = nx.DiGraph()
 
         # occ 3dviewer
         self._display = Viewer3d()
@@ -38,6 +70,22 @@ class GdsEditor(QWidget):
         self._move_start_y = None
 
         self._selected_shape = None
+
+    def sizeHint(self):
+        return QSize(800, 600)
+
+    def handleMenuAction(self, action, pos):
+        lpos = self.mapFromGlobal(pos)
+
+        if action == GdsEditor.Action.SHOW_IN_INTERPRETER:
+            self._display.Select(lpos.x(), lpos.y())
+            selected_shape = self._display.Context.SelectedInteractive()
+            if selected_shape is not None:
+                self._display.Context.ClearSelected(True)
+                ais_shape = AIS.AIS_Shape.DownCast(selected_shape)
+                component = list(
+                    self.component_shape_map.predecessors(ais_shape))[0]
+                self.sendObjToInterpreter.emit({"selec_component": component})
 
     def resizeEvent(self, event):
         super(GdsEditor, self).resizeEvent(event)
@@ -71,12 +119,15 @@ class GdsEditor(QWidget):
         if button == Qt.MouseButton.LeftButton:
             self._pan_start_x = pos.x()
             self._pan_start_y = pos.y()
-        elif button == Qt.MouseButton.RightButton:
+        elif button == Qt.MouseButton.MiddleButton:
             self._move_start_x = pos.x()
             self._move_start_y = pos.y()
             self._display.Context.ClearSelected(True)
             self._display.Select(pos.x(), pos.y())
             self._selected_shape = self._display.Context.SelectedInteractive()
+        elif button == Qt.MouseButton.RightButton:
+            gpos = self.mapToGlobal(pos)
+            self.right_menu.popup(gpos)
 
     def mouseMoveEvent(self, event):
         pos = event.pos()
@@ -88,7 +139,7 @@ class GdsEditor(QWidget):
             self._pan_start_x = pos.x()
             self._pan_start_y = pos.y()
             self._display.Pan(dx, -dy)
-        if buttons == Qt.MouseButton.RightButton and self._selected_shape:
+        if buttons == Qt.MouseButton.MiddleButton and self._selected_shape:
             # translate view coord to real coord
             view = self._display.View
             v1 = view.Convert(self._move_start_x, self._move_start_y)
@@ -108,7 +159,7 @@ class GdsEditor(QWidget):
 
     def mouseReleaseEvent(self, event):
         button = event.button()
-        if button == Qt.MouseButton.RightButton:
+        if button == Qt.MouseButton.MiddleButton:
             self._selected_shape = None
             self._display.Context.ClearSelected(True)
 
@@ -118,6 +169,31 @@ class GdsEditor(QWidget):
                 self._display.DisplayShape(
                     s, color=Quantity.Quantity_NameOfColor.Quantity_NOC_CORAL, transparency=0.8)
         viewer._display.FitAll()
+
+    def showComponents(self, components: list):
+        for i in components:
+            for shape in i.draw_shape().shapes:
+                ais_shapes = self._display.DisplayShape(
+                    shape, color=Quantity.Quantity_NameOfColor.Quantity_NOC_CORAL, transparency=0.8)
+                for a in ais_shapes:
+                    self.component_shape_map.add_edge(i, a)
+        viewer._display.FitAll()
+
+    def updateComponent(self, comp):
+        if comp in self.component_shape_map:
+            for shape in self.component_shape_map.successors(comp):
+                # save trans
+                trans = shape.Transformation()
+                self._display.Context.Erase(shape, False)
+
+            for shape in comp.draw_shape().shapes:
+                ais_shapes = self._display.DisplayShape(
+                    shape, color=Quantity.Quantity_NameOfColor.Quantity_NOC_CORAL, transparency=0.8)
+                for a in ais_shapes:
+                    self.component_shape_map.add_edge(comp, a)
+                    # apply transformation to new shape
+                    a.SetLocalTransformation(trans)
+            viewer._display.FitAll()
 
     def drawSelectBox(self, event):
         tolerance = 2
@@ -135,6 +211,7 @@ class GdsEditor(QWidget):
 if __name__ == "__main__":
     import sys
     import os
+    from PyQt5.QtWidgets import QVBoxLayout, QMainWindow
     from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
     current_path = os.path.dirname(os.path.abspath(__file__))
     PROJ_PATH = os.path.abspath(os.path.join(
@@ -142,6 +219,7 @@ if __name__ == "__main__":
     sys.path.append(PROJ_PATH)
     from library.qubits import transmon
     from library.coupling_lines import coupling_line_straight
+    from GUI.gui_modules.Command.Python_Interpreter import PythonInterpreter
     import gdsocc
     # from api.design import Design
 
@@ -153,11 +231,27 @@ if __name__ == "__main__":
     # design.gds.show_svg()
 
     app = QApplication([])
+    main_w = QMainWindow()
+
+    vlayout = QVBoxLayout()
+    main_widget = QWidget()
+    main_widget.setLayout(vlayout)
+
+    main_w.setCentralWidget(main_widget)
+
     viewer = GdsEditor()
+    viewer.setBaseSize
+    vlayout.addWidget(viewer)
     qubit = transmon.Transmon({})
     cpl = coupling_line_straight.CouplingLineStraight({})
 
-    viewer.showTopoDS([qubit.draw_shape(), cpl.draw_shape()])
+    # viewer.showTopoDS([qubit.draw_shape(), cpl.draw_shape()])
+    viewer.showComponents([qubit, cpl])
 
-    viewer.show()
+    pyinp = PythonInterpreter()
+    pyinp.addLocalsVar({"viewer":  viewer})
+    pyinp.clear_output()
+    viewer.sendObjToInterpreter.connect(pyinp.addLocalsVar)
+    vlayout.addWidget(pyinp)
+    main_w.show()
     sys.exit(app.exec_())


### PR DESCRIPTION
This PR is just for show the code working progress. You can ignore it.
gdseditor can change component from integrated python interpreter now, like this:
![gdseditor](https://github.com/user-attachments/assets/9da3a7e4-2c01-493c-bce7-3a3b05cc7a22)

- [x] modify component by change parameters or from gui interactively
- [ ] modify whole chip layout from gui
- [ ] preview gds layout and save to gds file (design will slightly different with real gds layout, for gds can not have real arc, and hole)
- [ ] auto aligning at edge when two components too close, less thran threshold
- [ ] auto spread air bridge under nearest neighbor distance requirement
- [ ] manufacturing simulation trans 2D design to 3D chip
- [ ] save 3D chip to igs/step CAD file can loaded by Ansys or HFSS for real physic numerical simulation